### PR TITLE
Prevent Slack from displaying 501 timeout's when giving new users authorization links

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,5 @@
 const app = require('express')();
 const bodyParser = require('body-parser');
-//const setupController = require('../controllers/setupController');
 const mongoose = require('mongoose');
 const dbconfig = require('../dbconfig');
 const port = process.env.VCAP_APP_PORT || 3000;
@@ -10,7 +9,6 @@ const cfenv = require('cfenv');
 const appEnv = cfenv.getAppEnv();
 let mongo_env = 'prod';
 if(appEnv.url.indexOf('local') > -1) { //if appEnv cannont find cfenv 'local', then we are running locally
-  //appEnv.url = undefined;
   mongo_env = 'dev';
 }
 

--- a/src/routes/callbacks/github.js
+++ b/src/routes/callbacks/github.js
@@ -190,7 +190,6 @@ async function getUsername(endpoint, token) {
     let response = await axios.get(`${endpoint}/user`,{
       headers: {'Authorization': `token ${token}`}
     });
-    console.log(`In get usename, about to return ${response.data.login}`);
     return response.data.login;
   } catch(error) {
     console.log(`there was an error while attempting to retrieve a user info from the access token created: ${error}`);

--- a/src/routes/slack.js
+++ b/src/routes/slack.js
@@ -12,7 +12,6 @@ const bot_token = process.env.BOT_TOKEN;
 const appEnv = cfenv.getAppEnv();
 if(appEnv.url.indexOf('local') > -1) { //if appEnv cannont find cfenv 'local', then we are running locally
   appEnv.url = undefined;
-  //mongo_env = 'dev';
 }
 const host = appEnv.url || process.env.NGROK;
 let ent_host = 'ibm';
@@ -30,9 +29,9 @@ module.exports = function(app) {
         res.send('there was an error retriving your config info');
         console.log(err);
       } else if (config.length == 0) { // this User has never authorized standup-helper
-        console.log(`host = ${host}`);
         let gh_auth_enterprise = `https://github.${ent_host}.com/login/oauth/authorize?client_id=${client_id_enterprise}&redirect_uri=${host}/callback/github&scope=notifications&state=${response_url}also${user_id}alsoenterprise&allow_signup=true`;
         let gh_auth_public = `https://github.com/login/oauth/authorize?client_id=${client_id_pub}&redirect_uri=${host}/callback/github&scope=notifications&state=${response_url}also${user_id}alsopublic&allow_signup=true`;
+        res.send('Authorize Standup-Helper by following both links below');
         authMessage(req.body,gh_auth_public,gh_auth_enterprise);
       } else { // there is configuration info stored already for this user
         try { 
@@ -112,7 +111,6 @@ module.exports = function(app) {
 // maybe this should return the response we get from slack and we should handle it in /slack?
 function authMessage(body,gh_auth_public,gh_auth_enterprise) {
   axios.post(body.response_url,{
-    'text': 'Authorize Standup-helper to access both your public and enterprise Github accounts',
     'attachments': [
       {
         'fallback': 'Authorize Standup-helper to access both your public and enterprise Github accounts',


### PR DESCRIPTION
Previously, Slack would display a 501 timeout error when new users went to use `/standup` because we were not sending a response back to the initial slack request and only using the response hook. We now send a response back using `res.send` and then use the response hook to send authorization links